### PR TITLE
fix: ATS例外設定でlocalhost HTTP接続を許可

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,4 @@ backend/npm-debug.log*
 
 # Swift Package (古いファイル)
 Sources/
-Info.plist
 Package.swift

--- a/ios/batON.xcodeproj/project.pbxproj
+++ b/ios/batON.xcodeproj/project.pbxproj
@@ -253,7 +253,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HTTR9BV5V6;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = batON/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -285,7 +286,8 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = HTTR9BV5V6;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = batON/Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios/batON/Info.plist
+++ b/ios/batON/Info.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- `Info.plist` を新規作成し、`NSAppTransportSecurity` で localhost への HTTP 接続を許可
- `project.pbxproj` を更新して自動生成 Info.plist を無効化し、カスタム Info.plist を参照するよう設定
- `.gitignore` から古い `Info.plist` 除外ルールを削除（Swift Package 時代の残骸）

## 背景

iOS の App Transport Security (ATS) がデフォルトで HTTP 通信をブロックするため、Docker 上の GraphQL API (`http://localhost:4000`) に接続できなかった。

## Test plan

- [ ] Xcode でビルドが通ること
- [ ] ログイン画面から GraphQL API に接続できること（Docker 起動時）
- [ ] API 未起動時はモックデータでフォールバックすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)