### PR TITLE
feat: ローディング状態・エラー表示のUX改善

### DIFF
--- a/ios/batON/AppViewModel.swift
+++ b/ios/batON/AppViewModel.swift
@@ -44,8 +44,12 @@ class AppViewModel: ObservableObject {
     @Published var kindnessActs: [KindnessAct] = []
     @Published var reports: [Report] = []
     @Published var isLoadingData: Bool = false
+    @Published var apiError: String? = nil
 
     private var userId: String = ""
+    private var pendingFetches: Int = 0 {
+        didSet { isLoadingData = pendingFetches > 0 }
+    }
 
     // MARK: - 統計
     var thisMonthActCount: Int {
@@ -69,9 +73,14 @@ class AppViewModel: ObservableObject {
 
     // MARK: - APIからデータ取得
     func loadFromAPI(userId: String) {
-        guard userId != "mock-user" else { return }
+        guard !userId.isEmpty, userId != "mock-user" else { return }
         self.userId = userId
-        isLoadingData = true
+        apiError = nil
+        // APIユーザーはモックデータを消去して実データに入れ替え
+        benefactors = []
+        kindnessActs = []
+        reports = []
+        pendingFetches = 3
         fetchBenefactors(userId: userId)
         fetchKindnessActs(userId: userId)
         fetchReports(userId: userId)
@@ -86,12 +95,19 @@ class AppViewModel: ObservableObject {
         }
         """
         APIService.shared.execute(query: query, variables: ["userId": userId]) { [weak self] (result: Result<BenefactorsData, Error>) in
-            if case .success(let data) = result {
-                self?.benefactors = data.benefactors.map {
-                    Benefactor(id: $0.id, name: $0.name, relation: $0.relation ?? "", kindnessDescription: $0.kindnessDescription ?? "", kindnessActCount: $0.kindnessActCount)
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.benefactors = data.benefactors.map {
+                        Benefactor(id: $0.id, name: $0.name, relation: $0.relation ?? "", kindnessDescription: $0.kindnessDescription ?? "", kindnessActCount: $0.kindnessActCount)
+                    }
+                case .failure(let error):
+                    if case APIError.networkError = error { } else {
+                        self?.apiError = "データの取得に失敗しました"
+                    }
                 }
+                self?.pendingFetches -= 1
             }
-            self?.isLoadingData = false
         }
     }
 
@@ -104,14 +120,17 @@ class AppViewModel: ObservableObject {
         }
         """
         APIService.shared.execute(query: query, variables: ["userId": userId]) { [weak self] (result: Result<KindnessActsData, Error>) in
-            if case .success(let data) = result {
-                let formatter = DateFormatter()
-                formatter.dateFormat = "yyyy-MM-dd"
-                self?.kindnessActs = data.kindnessActs.compactMap { act in
-                    let date = formatter.date(from: String(act.actDate.prefix(10))) ?? Date()
-                    let category = KindnessCategory(rawValue: act.category) ?? .other
-                    return KindnessAct(id: act.id, benefactorId: act.benefactorId, title: act.title, description: act.description ?? "", category: category, actDate: date, recipientName: act.recipientName, isReported: act.isReported)
+            DispatchQueue.main.async {
+                if case .success(let data) = result {
+                    let formatter = DateFormatter()
+                    formatter.dateFormat = "yyyy-MM-dd"
+                    self?.kindnessActs = data.kindnessActs.compactMap { act in
+                        let date = formatter.date(from: String(act.actDate.prefix(10))) ?? Date()
+                        let category = KindnessCategory(rawValue: act.category) ?? .other
+                        return KindnessAct(id: act.id, benefactorId: act.benefactorId, title: act.title, description: act.description ?? "", category: category, actDate: date, recipientName: act.recipientName, isReported: act.isReported)
+                    }
                 }
+                self?.pendingFetches -= 1
             }
         }
     }
@@ -125,15 +144,18 @@ class AppViewModel: ObservableObject {
         }
         """
         APIService.shared.execute(query: query, variables: ["userId": userId]) { [weak self] (result: Result<ReportsData, Error>) in
-            if case .success(let data) = result {
-                let formatter = ISO8601DateFormatter()
-                self?.reports = data.reports.compactMap { r in
-                    let date = formatter.date(from: r.createdAt) ?? Date()
-                    let status: ReportStatus = r.status == "SENT" ? .sent : .draft
-                    let act = self?.kindnessActs.first { $0.id == r.kindnessActId }
-                    let benefactor = self?.benefactors.first { $0.id == r.benefactorId }
-                    return Report(id: r.id, kindnessActId: r.kindnessActId, benefactorId: r.benefactorId, activityTitle: act?.title ?? "", benefactorName: benefactor?.name ?? "", message: r.message, status: status, createdAt: date)
+            DispatchQueue.main.async {
+                if case .success(let data) = result {
+                    let formatter = ISO8601DateFormatter()
+                    self?.reports = data.reports.compactMap { r in
+                        let date = formatter.date(from: r.createdAt) ?? Date()
+                        let status: ReportStatus = r.status == "SENT" ? .sent : .draft
+                        let act = self?.kindnessActs.first { $0.id == r.kindnessActId }
+                        let benefactor = self?.benefactors.first { $0.id == r.benefactorId }
+                        return Report(id: r.id, kindnessActId: r.kindnessActId, benefactorId: r.benefactorId, activityTitle: act?.title ?? "", benefactorName: benefactor?.name ?? "", message: r.message, status: status, createdAt: date)
+                    }
                 }
+                self?.pendingFetches -= 1
             }
         }
     }

--- a/ios/batON/ContentView.swift
+++ b/ios/batON/ContentView.swift
@@ -32,6 +32,9 @@ struct ContentView: View {
         .onAppear {
             appViewModel.loadFromAPI(userId: authViewModel.currentUserId)
         }
+        .onChange(of: authViewModel.currentUserId) { newId in
+            appViewModel.loadFromAPI(userId: newId)
+        }
     }
 }
 

--- a/ios/batON/Views/ActivityListView.swift
+++ b/ios/batON/Views/ActivityListView.swift
@@ -22,7 +22,19 @@ struct ActivityListView: View {
                 }
                 .padding()
 
-                if appViewModel.kindnessActs.isEmpty {
+                if appViewModel.isLoadingData {
+                    Spacer()
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.3)
+                            .tint(Color.batPrimary)
+                        Text("読み込み中…")
+                            .font(.system(size: 14))
+                            .foregroundColor(Color.batTextSecondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    Spacer()
+                } else if appViewModel.kindnessActs.isEmpty {
                     Spacer()
                     VStack(spacing: 12) {
                         Text("✨")

--- a/ios/batON/Views/AddKindnessActView.swift
+++ b/ios/batON/Views/AddKindnessActView.swift
@@ -11,6 +11,7 @@ struct AddKindnessActView: View {
     @State private var actDate = Date()
     @State private var recipientName = ""
     @State private var errorMessage = ""
+    @State private var isSaving = false
 
     var body: some View {
         ZStack {
@@ -132,9 +133,14 @@ struct AddKindnessActView: View {
                                 .frame(maxWidth: .infinity, alignment: .leading)
                         }
 
-                        BatPrimaryButton(title: "記録する", icon: "checkmark.circle.fill") {
+                        BatPrimaryButton(
+                            title: isSaving ? "記録中…" : "記録する",
+                            icon: isSaving ? "hourglass" : "checkmark.circle.fill"
+                        ) {
                             save()
                         }
+                        .disabled(isSaving)
+                        .opacity(isSaving ? 0.7 : 1)
                     }
                     .padding(.horizontal, 24)
                     .padding(.bottom, 32)
@@ -148,6 +154,8 @@ struct AddKindnessActView: View {
         guard !selectedBenefactorId.isEmpty else { errorMessage = "恩人を選択してください"; return }
         guard !recipientName.isEmpty else { errorMessage = "受益者を入力してください"; return }
 
+        isSaving = true
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
         appViewModel.addKindnessAct(
             benefactorId: selectedBenefactorId,
             title: title,

--- a/ios/batON/Views/BenefactorListView.swift
+++ b/ios/batON/Views/BenefactorListView.swift
@@ -22,7 +22,19 @@ struct BenefactorListView: View {
                 }
                 .padding()
 
-                if appViewModel.benefactors.isEmpty {
+                if appViewModel.isLoadingData {
+                    Spacer()
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.3)
+                            .tint(Color.batPrimary)
+                        Text("読み込み中…")
+                            .font(.system(size: 14))
+                            .foregroundColor(Color.batTextSecondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    Spacer()
+                } else if appViewModel.benefactors.isEmpty {
                     Spacer()
                     VStack(spacing: 12) {
                         Text("🤝")

--- a/ios/batON/Views/DashboardView.swift
+++ b/ios/batON/Views/DashboardView.swift
@@ -114,6 +114,56 @@ struct DashboardView: View {
             AddKindnessActView()
                 .environmentObject(appViewModel)
         }
+        .overlay(loadingOverlay)
+        .overlay(errorBanner, alignment: .top)
+        .animation(.easeInOut(duration: 0.3), value: appViewModel.apiError)
+    }
+
+    @ViewBuilder
+    private var loadingOverlay: some View {
+        if appViewModel.isLoadingData {
+            ZStack {
+                Color.black.opacity(0.3).ignoresSafeArea()
+                VStack(spacing: 16) {
+                    ProgressView()
+                        .scaleEffect(1.5)
+                        .tint(.white)
+                    Text("データを読み込み中…")
+                        .font(.system(size: 14))
+                        .foregroundColor(.white)
+                }
+                .padding(32)
+                .background(Color.batCard.opacity(0.95))
+                .cornerRadius(20)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var errorBanner: some View {
+        if let error = appViewModel.apiError {
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundColor(.orange)
+                Text(error)
+                    .font(.system(size: 13))
+                    .foregroundColor(Color.batTextPrimary)
+                Spacer()
+                Button { appViewModel.apiError = nil } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 12, weight: .bold))
+                        .foregroundColor(Color.batTextSecondary)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(Color.batCard)
+            .cornerRadius(12)
+            .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
+            .padding(.horizontal)
+            .padding(.top, 8)
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
     }
 }
 

--- a/ios/batON/Views/SendReportView.swift
+++ b/ios/batON/Views/SendReportView.swift
@@ -6,6 +6,7 @@ struct SendReportView: View {
     @Environment(\.presentationMode) private var presentationMode
 
     @State private var message = ""
+    @State private var isSending = false
 
     var benefactor: Benefactor? { appViewModel.benefactor(for: act.benefactorId) }
 
@@ -109,9 +110,14 @@ struct SendReportView: View {
                             }
                         }
 
-                        BatPrimaryButton(title: "報告を送る", icon: "paperplane.fill") {
+                        BatPrimaryButton(
+                            title: isSending ? "送信中…" : "報告を送る",
+                            icon: isSending ? "hourglass" : "paperplane.fill"
+                        ) {
                             send()
                         }
+                        .disabled(isSending || message.isEmpty)
+                        .opacity(isSending || message.isEmpty ? 0.7 : 1)
                     }
                     .padding(.horizontal, 24)
                     .padding(.bottom, 32)
@@ -121,6 +127,9 @@ struct SendReportView: View {
     }
 
     private func send() {
+        guard !message.isEmpty else { return }
+        isSending = true
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
         let b = benefactor
         appViewModel.sendReport(
             for: act,


### PR DESCRIPTION
## Summary

Closes #6

- **AppViewModel**: `pendingFetches` カウンターで3並列fetchの完了を正確に追跡。APIユーザーログイン時にモックデータを消去して実データに入れ替え。`apiError` プロパティ追加
- **ContentView**: `onChange(userId)` でログイン後に自動APIロードを実行
- **DashboardView**: ローディング中はモーダルオーバーレイ、エラー時はトップバナー表示
- **ActivityListView / BenefactorListView**: ロード中は `ProgressView`（空状態と区別）
- **AddKindnessActView / SendReportView**: 送信中はボタン無効化 + ハプティクスフィードバック

## Test plan

- [ ] ログイン後にダッシュボードでローディング表示が出ること
- [ ] API接続エラー時にエラーバナーが表示されること
- [ ] 活動記録時に「記録中…」ボタン表示になること
- [ ] 報告送信でメッセージ空のときボタンが無効になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)