### PR TITLE
feat: 感謝チェーン可視化を実データで動的描画

### DIFF
--- a/ios/batON/Views/DashboardView.swift
+++ b/ios/batON/Views/DashboardView.swift
@@ -50,7 +50,9 @@ struct DashboardView: View {
                                 .font(.system(size: 18, weight: .bold))
                                 .foregroundColor(Color.batTextPrimary)
                             Spacer()
-                            NavigationLink(destination: GratitudeChain3DView()) {
+                            NavigationLink(destination: GratitudeChain3DView()
+                                .environmentObject(appViewModel)
+                            ) {
                                 Text("詳細 →")
                                     .font(.system(size: 13))
                                     .foregroundColor(Color.batSecondary)
@@ -58,18 +60,31 @@ struct DashboardView: View {
                         }
 
                         VStack(spacing: 0) {
-                            if let first = appViewModel.benefactors.first {
-                                ChainNode(name: first.name, role: "恩人", color: Color.batAccent)
+                            // 恩人（最大3人まで横並び）
+                            if appViewModel.benefactors.isEmpty {
+                                ChainNode(name: "恩人未登録", role: "恩人", color: Color.batAccent)
                             } else {
-                                ChainNode(name: "恩人", role: "恩人", color: Color.batAccent)
+                                HStack(spacing: 12) {
+                                    ForEach(Array(appViewModel.benefactors.prefix(3))) { b in
+                                        ChainNode(name: b.name, role: "恩人", color: Color.batAccent)
+                                    }
+                                }
                             }
                             ChainArrow()
                             ChainNode(name: authViewModel.currentUserName.isEmpty ? "あなた" : authViewModel.currentUserName, role: "ユーザー", color: Color.batPrimary)
                             ChainArrow()
-                            HStack(spacing: 12) {
-                                let recentActs = appViewModel.kindnessActs.prefix(3)
-                                ForEach(Array(recentActs), id: \.id) { act in
-                                    ChainNode(name: act.recipientName, role: "受益者", color: Color.batSecondary)
+                            // 受益者（重複排除 + 最大3人まで）
+                            let uniqueRecipients = Array(
+                                Dictionary(grouping: appViewModel.kindnessActs, by: { $0.recipientName })
+                                    .keys.prefix(3)
+                            )
+                            if uniqueRecipients.isEmpty {
+                                ChainNode(name: "受益者未記録", role: "受益者", color: Color.batSecondary)
+                            } else {
+                                HStack(spacing: 12) {
+                                    ForEach(uniqueRecipients, id: \.self) { name in
+                                        ChainNode(name: name, role: "受益者", color: Color.batSecondary)
+                                    }
                                 }
                             }
                         }

--- a/ios/batON/Views/GratitudeChain3DView.swift
+++ b/ios/batON/Views/GratitudeChain3DView.swift
@@ -281,15 +281,49 @@ struct GratitudeChainSceneView: UIViewRepresentable {
 
 // MARK: - SwiftUI ラッパー
 struct GratitudeChain3DView: View {
-    @State private var selectedNode: String? = nil
+    @EnvironmentObject var appViewModel: AppViewModel
+    var userName: String = "あなた"
 
-    let sampleNodes: [ChainNodeData] = [
-        ChainNodeData(id: "b1", name: "田中太郎", role: .benefactor, level: 0, connections: ["u1"]),
-        ChainNodeData(id: "u1", name: "あなた", role: .user, level: 1, connections: ["r1", "r2", "r3"]),
-        ChainNodeData(id: "r1", name: "山田", role: .recipient, level: 2),
-        ChainNodeData(id: "r2", name: "佐藤", role: .recipient, level: 2),
-        ChainNodeData(id: "r3", name: "鈴木", role: .recipient, level: 2),
-    ]
+    // 実データからノードを構築
+    private var chainNodes: [ChainNodeData] {
+        let userId = "u1"
+        var nodes: [ChainNodeData] = []
+
+        // 恩人ノード（ユーザーノードに接続）
+        let benefactorIds = appViewModel.benefactors.map { $0.id }
+        for b in appViewModel.benefactors {
+            nodes.append(ChainNodeData(id: b.id, name: b.name, role: .benefactor, level: 0, connections: [userId]))
+        }
+
+        // 受益者ノード（重複を名前で排除）
+        var recipientNames: [String] = []
+        var recipientNodes: [ChainNodeData] = []
+        for act in appViewModel.kindnessActs {
+            let name = act.recipientName
+            if !recipientNames.contains(name) {
+                recipientNames.append(name)
+                recipientNodes.append(ChainNodeData(id: "r_\(name)", name: name, role: .recipient, level: 2))
+            }
+        }
+
+        // ユーザーノード（受益者に接続）
+        let recipientIds = recipientNodes.map { $0.id }
+        let userNode = ChainNodeData(id: userId, name: userName, role: .user, level: 1, connections: recipientIds)
+        nodes.append(userNode)
+        nodes.append(contentsOf: recipientNodes)
+
+        // データがない場合はサンプルを返す
+        if nodes.count == 1 {
+            return [
+                ChainNodeData(id: userId, name: userName, role: .user, level: 1, connections: [])
+            ]
+        }
+        return nodes
+    }
+
+    private var benefactorCount: Int { appViewModel.benefactors.count }
+    private var recipientCount: Int { Set(appViewModel.kindnessActs.map { $0.recipientName }).count }
+    private var connectionCount: Int { benefactorCount + recipientCount }
 
     var body: some View {
         ZStack {
@@ -310,12 +344,29 @@ struct GratitudeChain3DView: View {
                 }
                 .padding()
 
-                // 3D ビュー
-                GratitudeChainSceneView(nodes: sampleNodes)
+                if appViewModel.benefactors.isEmpty && appViewModel.kindnessActs.isEmpty {
+                    // Empty State
+                    VStack(spacing: 16) {
+                        Text("🌐")
+                            .font(.system(size: 64))
+                        Text("チェーンがまだありません")
+                            .font(.system(size: 16, weight: .medium))
+                            .foregroundColor(Color.batTextSecondary)
+                        Text("恩人を登録して活動を記録すると\nここに感謝のつながりが広がります")
+                            .font(.system(size: 13))
+                            .foregroundColor(Color.batTextSecondary)
+                            .multilineTextAlignment(.center)
+                    }
                     .frame(maxWidth: .infinity)
-                    .frame(height: UIScreen.main.bounds.height * 0.55)
-                    .cornerRadius(20)
-                    .padding(.horizontal)
+                    .frame(height: UIScreen.main.bounds.height * 0.45)
+                } else {
+                    // 3D ビュー
+                    GratitudeChainSceneView(nodes: chainNodes)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: UIScreen.main.bounds.height * 0.55)
+                        .cornerRadius(20)
+                        .padding(.horizontal)
+                }
 
                 // 凡例
                 HStack(spacing: 24) {
@@ -325,13 +376,13 @@ struct GratitudeChain3DView: View {
                 }
                 .padding(.top, 20)
 
-                // 統計
+                // 統計（実データ）
                 HStack(spacing: 0) {
-                    Chain3DStatItem(value: "1", label: "恩人")
+                    Chain3DStatItem(value: "\(benefactorCount)", label: "恩人")
                     Divider().frame(height: 36).background(Color.batCardLight)
-                    Chain3DStatItem(value: "3", label: "受益者")
+                    Chain3DStatItem(value: "\(recipientCount)", label: "受益者")
                     Divider().frame(height: 36).background(Color.batCardLight)
-                    Chain3DStatItem(value: "4", label: "繋がり")
+                    Chain3DStatItem(value: "\(connectionCount)", label: "繋がり")
                 }
                 .padding(.vertical, 16)
                 .background(Color.batCard)
@@ -380,4 +431,5 @@ struct Chain3DStatItem: View {
 
 #Preview {
     GratitudeChain3DView()
+        .environmentObject(AppViewModel())
 }


### PR DESCRIPTION
## Summary

Closes #7

- **GratitudeChain3DView**: `AppViewModel` の実データ（benefactors / kindnessActs）からノードを動的に構築
  - 恩人 → ユーザー → 受益者の接続グラフを自動生成（受益者名は重複排除）
  - 統計カード（恩人数・受益者数・繋がり数）をリアルタイムで表示
  - データがない場合は空状態UIを表示
- **DashboardView**: チェーンカードを複数恩人対応（最大3人横並び）、受益者も重複排除

## Test plan

- [ ] 恩人・活動を登録後、感謝チェーン詳細で3Dグラフに実データが反映されること
- [ ] ダッシュボードのチェーンカードに複数恩人が表示されること
- [ ] データゼロ時にEmpty Stateが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)