### PR TITLE
feat: アプリ全体のポリッシュ・仕上げ (#9)

### DIFF
--- a/ios/batON/AppViewModel.swift
+++ b/ios/batON/AppViewModel.swift
@@ -63,6 +63,7 @@ class AppViewModel: ObservableObject {
     @Published var posts: [Post] = []
     @Published var isLoadingData: Bool = false
     @Published var apiError: String? = nil
+    @Published var unreadMessageCount: Int = 0
 
     private var userId: String = ""
     private var pendingFetches: Int = 0 {

--- a/ios/batON/ContentView.swift
+++ b/ios/batON/ContentView.swift
@@ -9,6 +9,7 @@ struct ContentView: View {
     @EnvironmentObject var authViewModel: AuthViewModel
     @State private var selectedTab: Tab = .home
     @State private var showChain = false
+    @State private var showConversations = false
 
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -31,20 +32,29 @@ struct ContentView: View {
             .padding(.bottom, 80) // タブバーの高さ分
 
             // カスタムタブバー
-            CustomTabBar(selectedTab: $selectedTab, showChain: $showChain)
+            CustomTabBar(selectedTab: $selectedTab, showChain: $showChain, unreadCount: appViewModel.unreadMessageCount)
         }
         .environmentObject(appViewModel)
         .ignoresSafeArea(.keyboard)
         .onAppear {
             appViewModel.loadFromAPI(userId: authViewModel.currentUserId)
+            appViewModel.loadPosts()
         }
         .onChange(of: authViewModel.currentUserId) { newId in
             appViewModel.loadFromAPI(userId: newId)
+            appViewModel.loadPosts()
         }
         .fullScreenCover(isPresented: $showChain) {
             ChainFullScreenView()
                 .environmentObject(appViewModel)
                 .environmentObject(authViewModel)
+        }
+        .sheet(isPresented: $showConversations) {
+            NavigationView {
+                ConversationsView()
+                    .environmentObject(appViewModel)
+                    .environmentObject(authViewModel)
+            }
         }
     }
 }
@@ -53,6 +63,7 @@ struct ContentView: View {
 struct CustomTabBar: View {
     @Binding var selectedTab: Tab
     @Binding var showChain: Bool
+    var unreadCount: Int = 0
 
     var body: some View {
         ZStack {
@@ -64,7 +75,7 @@ struct CustomTabBar: View {
                 // 中央ボタンのスペース
                 Color.clear.frame(width: 72)
 
-                TabBarItem(icon: "heart.fill", label: "マッチング", tab: .matching, selectedTab: $selectedTab)
+                TabBarItem(icon: "heart.fill", label: "マッチング", tab: .matching, selectedTab: $selectedTab, badge: unreadCount)
                 TabBarItem(icon: "person.fill", label: "プロフィール", tab: .profile, selectedTab: $selectedTab)
             }
             .frame(height: 64)
@@ -108,6 +119,7 @@ struct TabBarItem: View {
     let label: String
     let tab: Tab
     @Binding var selectedTab: Tab
+    var badge: Int = 0
 
     var isSelected: Bool { selectedTab == tab }
 
@@ -116,9 +128,22 @@ struct TabBarItem: View {
             selectedTab = tab
         } label: {
             VStack(spacing: 4) {
-                Image(systemName: icon)
-                    .font(.system(size: 20))
-                    .foregroundColor(isSelected ? Color.batPrimary : Color.batTextSecondary)
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: icon)
+                        .font(.system(size: 20))
+                        .foregroundColor(isSelected ? Color.batPrimary : Color.batTextSecondary)
+
+                    if badge > 0 {
+                        Text(badge > 99 ? "99+" : "\(badge)")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 2)
+                            .background(Color.red)
+                            .clipShape(Capsule())
+                            .offset(x: 10, y: -6)
+                    }
+                }
                 Text(label)
                     .font(.system(size: 10))
                     .foregroundColor(isSelected ? Color.batPrimary : Color.batTextSecondary)

--- a/ios/batON/Views/ConversationsView.swift
+++ b/ios/batON/Views/ConversationsView.swift
@@ -33,20 +33,11 @@ struct ConversationsView: View {
 
                 // 会話一覧
                 if conversations.isEmpty {
-                    VStack(spacing: 16) {
-                        Spacer()
-                        Image(systemName: "bubble.left.and.bubble.right")
-                            .font(.system(size: 48))
-                            .foregroundColor(Color.batTextSecondary)
-                        Text("メッセージがありません")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(Color.batTextPrimary)
-                        Text("誰かとチャットを始めましょう")
-                            .font(.system(size: 13))
-                            .foregroundColor(Color.batTextSecondary)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity)
+                    EmptyStateView(
+                        icon: "bubble.left.and.bubble.right",
+                        title: "メッセージがありません",
+                        message: "マッチングした相手とチャットを始めましょう"
+                    )
                 } else {
                     ScrollView {
                         VStack(spacing: 0) {

--- a/ios/batON/Views/DashboardView.swift
+++ b/ios/batON/Views/DashboardView.swift
@@ -4,6 +4,7 @@ struct DashboardView: View {
     @EnvironmentObject var appViewModel: AppViewModel
     @EnvironmentObject var authViewModel: AuthViewModel
     @State private var showAddAct = false
+    @State private var showConversations = false
 
     var body: some View {
         ZStack {
@@ -18,16 +19,39 @@ struct DashboardView: View {
                             Text("こんにちは 👋")
                                 .font(.system(size: 14))
                                 .foregroundColor(Color.batTextSecondary)
-                            Text("今日も恩を送ろう")
+                            Text(authViewModel.currentUserName.isEmpty ? "今日も恩を送ろう" : "\(authViewModel.currentUserName)さん")
                                 .font(.system(size: 24, weight: .bold))
                                 .foregroundColor(Color.batTextPrimary)
                         }
                         Spacer()
+
+                        // DM ボタン
+                        Button {
+                            showConversations = true
+                        } label: {
+                            ZStack(alignment: .topTrailing) {
+                                Image(systemName: "bubble.right.fill")
+                                    .font(.system(size: 20))
+                                    .foregroundColor(Color.batTextSecondary)
+                                    .frame(width: 44, height: 44)
+                                    .background(Color.batCard)
+                                    .clipShape(Circle())
+
+                                if appViewModel.unreadMessageCount > 0 {
+                                    Circle()
+                                        .fill(Color.red)
+                                        .frame(width: 10, height: 10)
+                                        .offset(x: 2, y: -2)
+                                }
+                            }
+                        }
+                        .padding(.trailing, 8)
+
                         Circle()
                             .fill(LinearGradient.batPrimaryGradient)
                             .frame(width: 44, height: 44)
                             .overlay(
-                                Text(String(authViewModel.currentUserName.prefix(1)))
+                                Text(String(authViewModel.currentUserName.prefix(1).isEmpty ? "?" : authViewModel.currentUserName.prefix(1)))
                                     .font(.system(size: 16, weight: .bold))
                                     .foregroundColor(.white)
                             )
@@ -124,6 +148,13 @@ struct DashboardView: View {
         .sheet(isPresented: $showAddAct) {
             AddKindnessActView()
                 .environmentObject(appViewModel)
+        }
+        .sheet(isPresented: $showConversations) {
+            NavigationView {
+                ConversationsView()
+                    .environmentObject(appViewModel)
+                    .environmentObject(authViewModel)
+            }
         }
         .overlay(loadingOverlay)
         .overlay(errorBanner, alignment: .top)

--- a/ios/batON/Views/EmptyStateView.swift
+++ b/ios/batON/Views/EmptyStateView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let message: String
+    var buttonTitle: String? = nil
+    var buttonAction: (() -> Void)? = nil
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            Image(systemName: icon)
+                .font(.system(size: 56))
+                .foregroundColor(Color.batTextSecondary.opacity(0.5))
+
+            VStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundColor(Color.batTextPrimary)
+
+                Text(message)
+                    .font(.system(size: 14))
+                    .foregroundColor(Color.batTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 32)
+            }
+
+            if let buttonTitle, let action = buttonAction {
+                Button(action: action) {
+                    Text(buttonTitle)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 24)
+                        .padding(.vertical, 12)
+                        .background(Color.batPrimary)
+                        .cornerRadius(20)
+                }
+                .padding(.top, 8)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/ios/batON/Views/FeedView.swift
+++ b/ios/batON/Views/FeedView.swift
@@ -61,20 +61,11 @@ struct FeedView: View {
                     }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 } else if filteredPosts.isEmpty {
-                    VStack(spacing: 16) {
-                        Spacer()
-                        Image(systemName: "sparkles")
-                            .font(.system(size: 48))
-                            .foregroundColor(Color.batTextSecondary)
-                        Text("投稿がありません")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(Color.batTextPrimary)
-                        Text("新しい投稿が増えるのを待ちましょう")
-                            .font(.system(size: 13))
-                            .foregroundColor(Color.batTextSecondary)
-                        Spacer()
-                    }
-                    .frame(maxWidth: .infinity)
+                    EmptyStateView(
+                        icon: "sparkles",
+                        title: "投稿がありません",
+                        message: "新しい投稿が増えるのを待ちましょう"
+                    )
                 } else {
                     ScrollView(.vertical, showsIndicators: false) {
                         VStack(spacing: 12) {

--- a/ios/batON/Views/MatchingView.swift
+++ b/ios/batON/Views/MatchingView.swift
@@ -98,20 +98,11 @@ struct MatchingView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: 16) {
-            Spacer()
-            Image(systemName: "heart.slash")
-                .font(.system(size: 48))
-                .foregroundColor(Color.batTextSecondary)
-            Text("マッチング相手がいません")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundColor(Color.batTextPrimary)
-            Text("新しい投稿を待ちましょう")
-                .font(.system(size: 13))
-                .foregroundColor(Color.batTextSecondary)
-            Spacer()
-        }
-        .frame(maxWidth: .infinity)
+        EmptyStateView(
+            icon: "heart.slash",
+            title: "マッチング相手がいません",
+            message: "フィードに投稿してスキルをアピールしましょう"
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
ハッカソン提出前の最終ポリッシュ。UI統一、DM導線追加、自動データロード対応。

## Changes

### 新規コンポーネント
- **EmptyStateView.swift**: 統一された空状態UI
  - icon/title/message/ボタン（任意）を設定可能
  - FeedView、MatchingView、ConversationsView に適用

### ContentView
- `loadPosts()` を onAppear/onChange に追加（ログイン後自動フィード取得）
- CustomTabBar にバッジ表示対応を追加（`unreadCount` パラメータ）

### TabBarItem
- バッジカウント対応（赤いカプセル型バッジ、99+対応）

### DashboardView
- ヘッダーをユーザー名表示に更新（「田中さん」）
- DM アクセスボタンを追加（💬アイコン → ConversationsView シート表示）
- 未読メッセージがある場合の赤ドット表示

### AppViewModel
- `unreadMessageCount` プロパティを追加

## Build Status
✅ ビルド成功
✅ 全EmptyState統一完了
✅ DM導線実装完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)